### PR TITLE
feat: add clients for rest of cosmos sdk modules

### DIFF
--- a/crates/regen-rs/src/client.rs
+++ b/crates/regen-rs/src/client.rs
@@ -1,7 +1,19 @@
 use std::time::Duration;
+use bip32::secp256k1::sha2::digest::typenum::Min;
 use tonic::transport::Channel;
 
 use crate::cosmos::bank_client::BankClient;
+use crate::cosmos::auth_client::AuthClient;
+use crate::cosmos::crisis_client::CrisisClient;
+use crate::cosmos::distribution_client::DistributionClient;
+use crate::cosmos::evidence_client::EvidenceClient;
+use crate::cosmos::feegrant_client::FeegrantClient;
+use crate::cosmos::gov_client::GovClient;
+use crate::cosmos::mint_client::MintClient;
+use crate::cosmos::slashing_client::SlashingClient;
+use crate::cosmos::staking_client::StakingClient;
+use crate::cosmos::upgrade_client::UpgradeClient;
+use crate::cosmos::vesting_client::VestingClient;
 use crate::error::{RegenError, Result};
 use crate::regen::data_client::DataClient;
 use crate::regen::eco_credit_client::EcoCreditClient;
@@ -39,6 +51,54 @@ impl Client {
 
     pub fn bank(&self) -> BankClient {
         BankClient::new(self.channel.clone())
+    }
+
+    pub fn auth(&self) -> AuthClient {
+        AuthClient::new(self.channel.clone())
+    }
+
+    pub fn authz(&self) -> AuthClient {
+        AuthClient::new(self.channel.clone())
+    }
+
+    pub fn gov(&self) -> GovClient {
+        GovClient::new(self.channel.clone())
+    }
+
+    pub fn crisis(&self) -> CrisisClient {
+        CrisisClient::new(self.channel.clone())
+    }
+
+    pub fn evidence(&self) -> EvidenceClient {
+        EvidenceClient::new(self.channel.clone())
+    }
+
+    pub fn distribution(&self) -> DistributionClient {
+        DistributionClient::new(self.channel.clone())
+    }
+
+    pub fn feegrant(&self) -> FeegrantClient {
+        FeegrantClient::new(self.channel.clone())
+    }
+
+    pub fn mint(&self) -> MintClient {
+        MintClient::new(self.channel.clone())
+    }
+
+    pub fn slashing(&self) -> SlashingClient {
+        SlashingClient::new(self.channel.clone())
+    }
+
+    pub fn staking(&self) -> StakingClient {
+        StakingClient::new(self.channel.clone())
+    }
+
+    pub fn upgrade(&self) -> UpgradeClient {
+        UpgradeClient::new(self.channel.clone())
+    }
+
+    pub fn vesting(&self) -> VestingClient {
+        VestingClient::new(self.channel.clone())
     }
 }
 

--- a/crates/regen-rs/src/cosmos/auth_client.rs
+++ b/crates/regen-rs/src/cosmos/auth_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::auth::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::auth::v1beta1::query_client::QueryClient;
+
+pub struct AuthClient {
+    channel: Channel,
+}
+
+impl AuthClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/authz_client.rs
+++ b/crates/regen-rs/src/cosmos/authz_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::authz::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::authz::v1beta1::query_client::QueryClient;
+
+pub struct AuthZClient {
+    channel: Channel,
+}
+
+impl AuthZClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/crisis_client.rs
+++ b/crates/regen-rs/src/cosmos/crisis_client.rs
@@ -1,0 +1,16 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::crisis::v1beta1::msg_client::MsgClient;
+
+pub struct CrisisClient {
+    channel: Channel,
+}
+
+impl CrisisClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/distribution_client.rs
+++ b/crates/regen-rs/src/cosmos/distribution_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::distribution::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::distribution::v1beta1::query_client::QueryClient;
+
+pub struct DistributionClient {
+    channel: Channel,
+}
+
+impl DistributionClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/evidence_client.rs
+++ b/crates/regen-rs/src/cosmos/evidence_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::evidence::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::evidence::v1beta1::query_client::QueryClient;
+
+pub struct EvidenceClient {
+    channel: Channel,
+}
+
+impl EvidenceClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/feegrant_client.rs
+++ b/crates/regen-rs/src/cosmos/feegrant_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::feegrant::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::feegrant::v1beta1::query_client::QueryClient;
+
+pub struct FeegrantClient {
+    channel: Channel,
+}
+
+impl FeegrantClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/gov_client.rs
+++ b/crates/regen-rs/src/cosmos/gov_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::gov::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::gov::v1beta1::query_client::QueryClient;
+
+pub struct GovClient {
+    channel: Channel,
+}
+
+impl GovClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/mint_client.rs
+++ b/crates/regen-rs/src/cosmos/mint_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::mint::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::mint::v1beta1::query_client::QueryClient;
+
+pub struct MintClient {
+    channel: Channel,
+}
+
+impl MintClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/mod.rs
+++ b/crates/regen-rs/src/cosmos/mod.rs
@@ -1,1 +1,14 @@
 pub mod bank_client;
+pub mod auth_client;
+pub mod authz_client;
+pub mod gov_client;
+pub mod crisis_client;
+pub mod distribution_client;
+pub mod evidence_client;
+pub mod feegrant_client;
+pub mod mint_client;
+pub mod params_client;
+pub mod slashing_client;
+pub mod staking_client;
+pub mod upgrade_client;
+pub mod vesting_client;

--- a/crates/regen-rs/src/cosmos/params_client.rs
+++ b/crates/regen-rs/src/cosmos/params_client.rs
@@ -1,0 +1,19 @@
+use tonic::transport::Channel;
+
+
+use cosmos_sdk_proto::cosmos::params::v1beta1::query_client::QueryClient;
+
+pub struct ParamsClient {
+    channel: Channel,
+}
+
+impl ParamsClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+}

--- a/crates/regen-rs/src/cosmos/slashing_client.rs
+++ b/crates/regen-rs/src/cosmos/slashing_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::slashing::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::slashing::v1beta1::query_client::QueryClient;
+
+pub struct SlashingClient {
+    channel: Channel,
+}
+
+impl SlashingClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/staking_client.rs
+++ b/crates/regen-rs/src/cosmos/staking_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::staking::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::staking::v1beta1::query_client::QueryClient;
+
+pub struct StakingClient {
+    channel: Channel,
+}
+
+impl StakingClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/upgrade_client.rs
+++ b/crates/regen-rs/src/cosmos/upgrade_client.rs
@@ -1,0 +1,22 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::upgrade::v1beta1::msg_client::MsgClient;
+use cosmos_sdk_proto::cosmos::upgrade::v1beta1::query_client::QueryClient;
+
+pub struct UpgradeClient {
+    channel: Channel,
+}
+
+impl UpgradeClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn query(&self) -> QueryClient<tonic::transport::Channel> {
+        QueryClient::new(self.channel.clone())
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}

--- a/crates/regen-rs/src/cosmos/vesting_client.rs
+++ b/crates/regen-rs/src/cosmos/vesting_client.rs
@@ -1,0 +1,18 @@
+use tonic::transport::Channel;
+
+use cosmos_sdk_proto::cosmos::vesting::v1beta1::msg_client::MsgClient;
+
+
+pub struct VestingClient {
+    channel: Channel,
+}
+
+impl VestingClient {
+    pub fn new(channel: Channel) -> Self {
+        Self { channel }
+    }
+
+    pub fn tx(&self) -> MsgClient<Channel> {
+        MsgClient::new(self.channel.clone())
+    }
+}


### PR DESCRIPTION
Adds the rest of clients for the remaining cosmos modules following patter of the `bank` module.

## AI Summary
This pull request expands the functionality of the `regen-rs` crate by introducing new client modules for interacting with various Cosmos SDK modules. It also updates the `Client` implementation to provide access to these newly added client modules. These changes enhance the crate's ability to interact with Cosmos SDK features programmatically.

### Addition of new client modules:
* Added new client modules for Cosmos SDK components, including `auth_client`, `authz_client`, `gov_client`, `crisis_client`, `distribution_client`, `evidence_client`, `feegrant_client`, `mint_client`, `params_client`, `slashing_client`, `staking_client`, `upgrade_client`, and `vesting_client`. Each module includes a `Client` struct with methods for creating query and transaction clients. (`crates/regen-rs/src/cosmos/mod.rs`, [crates/regen-rs/src/cosmos/mod.rsR2-R14](diffhunk://#diff-cb3f51b3b5b69f91feda9420533320e14b5527390b3ef5675763b373d58b1077R2-R14))

### Updates to `Client` implementation:
* Modified the `Client` struct in `crates/regen-rs/src/client.rs` to include methods for accessing the newly added Cosmos SDK client modules. Each method initializes the respective client with the shared gRPC channel.

### Specific client implementations:
* Added `AuthClient` and `AuthZClient` implementations to interact with the Cosmos SDK's authentication and authorization modules. These clients provide methods for querying and sending transactions. (`crates/regen-rs/src/cosmos/auth_client.rs`, [[1]](diffhunk://#diff-67c4d39ef661447fb887ec2d1072bdbc91a1f3521530172d0db99e0deaefb8a7R1-R22); `crates/regen-rs/src/cosmos/authz_client.rs`, [[2]](diffhunk://#diff-d0b94cdd95a50b617e9b340c25a0163ce770ec9ce0c70397d72ecc56e3b45ff8R1-R22)
* Added implementations for various other Cosmos SDK modules, such as `GovClient`, `CrisisClient`, `DistributionClient`, `EvidenceClient`, `FeegrantClient`, `MintClient`, `ParamsClient`, `SlashingClient`, `StakingClient`, `UpgradeClient`, and `VestingClient`. Each client provides similar methods for querying and sending transactions. [[1]](diffhunk://#diff-2b03047a1e60267105ce0f99ad33daae5f77e74e8716df7a39a9d7679b380582R1-R22) [[2]](diffhunk://#diff-864b1c9c592d28e069983ddc81613e17b5d20315d4544be56559c5b53bfa0c28R1-R16) [[3]](diffhunk://#diff-5731b4aa6c639a61469aa992bcf3fd12adc49985c52b9e59be5c630d0380d389R1-R22) [[4]](diffhunk://#diff-b66bb6cfba9cb08fb324eb26a0431b2273cf1c5b802b882dc20cf30241b9def0R1-R22) [[5]](diffhunk://#diff-a7f4ed35cc165c7dcc6558c3e45af605e775dc187876982588b254e84b6fcca7R1-R22) [[6]](diffhunk://#diff-3130fbd5b196d2837a666173df2fffeb8c62ebf0eebe2b786ec398c20cd20031R1-R22) [[7]](diffhunk://#diff-7729a9285aa2f15509ff2ce62d333456e30731076f05e8faf289cc8a995ac2b1R1-R19) [[8]](diffhunk://#diff-b840634e582a5053a49978aa4256f3254689724d4fee6cb956f4a304746e84b2R1-R22) [[9]](diffhunk://#diff-7559713f576e5aa7fa453720d0588a5e28399cb57da504d497a48ca7bb4a30cfR1-R22) [[10]](diffhunk://#diff-9e5bd27a4092798a574d85f46223288c1f8bce0ac0cf48f728d21b652c83b112R1-R22) [[11]](diffhunk://#diff-c9c6971d07e77dfb54540b10e7dfa28b629688d8222f9dce3d692f54ca62d941R1-R18)

These changes significantly enhance the functionality of the `regen-rs` crate, making it more versatile for developers working with Cosmos SDK-based blockchain applications.