### PR TITLE
add unit tests for subscriber

### DIFF
--- a/crates/regen-rs/src/events/subscriber.rs
+++ b/crates/regen-rs/src/events/subscriber.rs
@@ -22,7 +22,6 @@ use log::{debug, error, info, trace, warn};
 
 pub type SubscriptionId = u32;
 
-#[derive(Debug)]
 pub enum Command {
     Subscribe(Subscription),
     Unsubscribe(SubscriptionId),

--- a/crates/regen-rs/src/events/subscriber.rs
+++ b/crates/regen-rs/src/events/subscriber.rs
@@ -22,6 +22,7 @@ use log::{debug, error, info, trace, warn};
 
 pub type SubscriptionId = u32;
 
+#[derive(Debug)]
 pub enum Command {
     Subscribe(Subscription),
     Unsubscribe(SubscriptionId),
@@ -317,5 +318,186 @@ impl Stream for EventSubscriber {
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Option<Self::Item>> {
         self.state.event_rx.poll_recv(cx)
+    }
+}
+
+mod tests {
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+    use tokio::time::{sleep, timeout, Duration};
+    use super::*;
+    use crate::RegenError;
+
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+    use futures::{StreamExt, SinkExt};
+
+    use tokio_tungstenite::tungstenite::{Message, Utf8Bytes};
+
+    async fn start_mock_ws_server(
+        received: Arc<Mutex<Vec<String>>>
+    ) -> (JoinHandle<()>, SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut ws_stream = accept_async(stream).await.unwrap();
+
+            while let Some(msg) = ws_stream.next().await {
+                if let Ok(Message::Text(text)) = msg {
+                    println!("[MOCK SERVER] Received: {}", text);
+                    received.lock().unwrap().push(text.clone().parse().unwrap()); // <--- record the message
+
+                    if text.contains("subscribe") {
+                        let fake_event = serde_json::json!({
+                        "type": "mock_event",
+                        "attributes": []
+                    });
+                        ws_stream.send(Message::Text(Utf8Bytes::from(fake_event.to_string()))).await.unwrap();
+                    }
+                }
+            }
+        });
+        (handle, addr)
+    }
+
+    #[tokio::test]
+    async fn test_new_event_subscriber_state()  {
+        let ws_url = "ws://localhost:26657/websocket".to_string();
+        let state = EventSubscriberState::new(ws_url).await.unwrap();
+        assert_eq!(state.next_id.load(Ordering::Relaxed), 0);
+        assert_eq!(state.subscriptions.read().await.len(), 0);
+        assert!(!state.command_tx.is_closed());
+        assert!(!state.event_rx.is_closed());
+        assert!(!state.supervisor_handle.is_finished());
+
+    }
+
+    #[tokio::test]
+    async fn test_new_event_subscriber() {
+        let ws_url = "ws://localhost:26657/websocket";
+        let subscriber = EventSubscriber::new(ws_url).await.unwrap();
+
+        assert!(subscriber.is_active());
+    }
+
+    #[tokio::test]
+    async fn test_subscribe(){
+        let ws_url = "ws://localhost:26657/websocket";
+        let mut subscriber = EventSubscriber::new(ws_url).await.unwrap();
+
+        let query = "tm.event='NewBlock'";
+        subscriber.subscribe(query).await.unwrap();
+
+        {
+            let subs = subscriber.state.subscriptions.read().await;
+            assert_eq!(subs.len(), 1);
+            assert!(subs.contains_key(&0));
+            let sub = subs.get(&0).unwrap();
+            assert_eq!(sub.query, query);
+        }
+        // Subscribe again and test id is increasing
+        subscriber.subscribe(query).await.unwrap();
+        let subs = subscriber.state.subscriptions.read().await;
+        assert_eq!(subs.len(), 2);
+        assert!(subs.contains_key(&1));
+        let sub = subs.get(&1).unwrap();
+        assert_eq!(sub.query, query);
+    }
+
+    async fn test_unsubscribe(){
+        let ws_url = "ws://localhost:26657/websocket";
+        let mut subscriber = EventSubscriber::new(ws_url).await.unwrap();
+
+        let query = "tm.event='NewBlock'";
+        subscriber.subscribe(query).await.unwrap();
+
+        let subs = subscriber.state.subscriptions.read().await;
+        assert_eq!(subs.len(), 1);
+        assert!(subs.contains_key(&0));
+
+        let subs = subscriber.state.subscriptions.read().await;
+        assert_eq!(subs.len(), 0);
+        assert!(!subs.contains_key(&0));
+    }
+    #[tokio::test]
+    async fn test_unsubscribe_sends_command() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let (mock_handle, addr) = start_mock_ws_server(received.clone()).await;
+        let ws_url = format!("ws://{}", addr);
+
+        let mut subscriber = EventSubscriber::new(&ws_url).await.unwrap();
+        subscriber.subscribe("tm.event='NewBlock'").await.unwrap();
+        subscriber.unsubscribe(0).await.unwrap();
+
+
+
+        let wait_for = async {
+            loop {
+                if received.lock().unwrap().len() >= 2 {
+                    break;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        };
+
+        timeout(Duration::from_secs(2), wait_for)
+            .await
+            .expect("Timeout waiting for websocket messages");
+
+        let msgs = received.lock().unwrap();
+        assert!(msgs.iter().any(|msg| msg.contains(r#""method":"subscribe""#) && msg.contains("tm.event='NewBlock'")));
+        assert!(msgs.iter().any(|msg| msg.contains(r#""method":"unsubscribe""#)));
+        mock_handle.abort();
+
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_makes_inactive() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let (mock_handle, addr) = start_mock_ws_server(received.clone()).await;
+        let ws_url = format!("ws://{}", addr);
+
+        let mut subscriber = EventSubscriber::new(&ws_url).await.unwrap();
+        assert!(subscriber.is_active());
+        subscriber.shutdown().await.unwrap();
+
+        // Poll until is_active returns false, or timeout after e.g. 1 second
+        use tokio::time::{timeout, sleep, Duration};
+        let wait_for = async {
+            loop {
+                if !subscriber.is_active() {
+                    break;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        };
+        timeout(Duration::from_secs(1), wait_for)
+            .await
+            .expect("Timeout waiting for subscriber to shut down");
+
+        mock_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_next_event_receives_event() {
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let (mock_handle, addr) = start_mock_ws_server(received.clone()).await;
+        let ws_url = format!("ws://{}", addr);
+
+        let mut subscriber = EventSubscriber::new(&ws_url).await.unwrap();
+        subscriber.subscribe("tm.event='NewBlock'").await.unwrap();
+
+        // Call next_event and expect to receive the mock event (from your mock server)
+        let event_opt = tokio::time::timeout(
+            Duration::from_secs(2),
+            subscriber.next_event(),
+        ).await.expect("Timeout waiting for event");
+
+        assert!(event_opt.is_some());
+        let event = event_opt.unwrap();
+        assert_eq!(event.r#type, "mock_event");
+
+        mock_handle.abort();
     }
 }


### PR DESCRIPTION
Add some unit tests for subscribe unsubcribe and close. Used a mock WS server to be able to record sent command and assert connections are working as expected. Future PRs will add integration tests against a real RPC